### PR TITLE
Redis expire

### DIFF
--- a/lib/storehouse/connections/redis.rb
+++ b/lib/storehouse/connections/redis.rb
@@ -51,7 +51,7 @@ module Storehouse
       protected
 
       def backup_expiration
-        known_timeout = (Storehouse.spec['timeouts'] || {})['write']
+        known_timeout = (Storehouse.spec['timeouts'] || {})['key_expiration']
         if known_timeout
           known_timeout * 2
         else

--- a/lib/storehouse/connections/redis.rb
+++ b/lib/storehouse/connections/redis.rb
@@ -14,7 +14,10 @@ module Storehouse
       end
 
       def write(path, hash)
-        @redis.hmset(path, *hash.to_a.flatten)
+        @redis.multi do
+          @redis.hmset(path, *hash.to_a.flatten)
+          @redis.expire(path, backup_expiration)
+        end
       end
 
       def delete(path)
@@ -42,6 +45,17 @@ module Storehouse
       def clear!(namespace = nil)
         @redis.keys("#{namespace}*").each do |key|
           @redis.del(key)
+        end
+      end
+
+      protected
+
+      def backup_expiration
+        known_timeout = (Storehouse.spec['timeouts'] || {})['write']
+        if known_timeout
+          known_timeout * 2
+        else
+          3600 * 24 * 14
         end
       end
 

--- a/lib/storehouse/version.rb
+++ b/lib/storehouse/version.rb
@@ -3,7 +3,7 @@ module Storehouse
 
     MAJOR = 0
     MINOR = 1
-    PATCH = 4
+    PATCH = 5
     PRE   = nil
 
 

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -40,6 +40,20 @@ describe Storehouse::Connections::Redis do
     objectc.should be_blank
   end
 
+  it 'should add an expiration time to all keys written to redis' do
+    true_redis_key = 'test:/some/path.html'
+    store.send(:connection_for).instance_variable_get('@redis').should_receive(:expire).with(true_redis_key, 1209600)
+    objecta = store.write('/some/path', 200, {'My Header' => 'Value'}, 'The actual content')
+  end
+
+  it 'should add an expiration time to all keys written to redis based on the timeout config if present' do
+    gem_config(:timeout, :namespace, :type => :redis)
+    true_redis_key = 'test:/some/path.html'
+    store.send(:connection_for).instance_variable_get('@redis').should_receive(:expire).with(true_redis_key, 3600 * 48)
+    objecta = store.write('/some/path', 200, {'My Header' => 'Value'}, 'The actual content')
+  end
+
+
   it 'should clear all objects' do
     store.clear!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,7 +116,8 @@ RSpec.configure do |config|
 
   def timeout_config
     simple_config.merge!({
-      'timeoutes' => {
+      'timeouts' => {
+        'key_expiration' => 3600 * 24,
         'read' => 0.2,
         'write' => 0.2
       }


### PR DESCRIPTION
This PR adds redis expiration to all keys written by storehouse.  This is in addition to Storehouse's normal expiration methods.  This will help ensure that no space is wasted in your redis server by old keys, and if you have a [redis expiration policy](http://oldblog.antirez.com/post/redis-as-LRU-cache.html) set, storehouse's keys will be swept.
